### PR TITLE
Headers not sent when pushing streams

### DIFF
--- a/packages/http-adapter/src/index.js
+++ b/packages/http-adapter/src/index.js
@@ -211,22 +211,22 @@ function createSocket(connection, stream, remote, {Socket, Peer, URI}) {
   if (stream && stream.pushAllowed) {
     onPush = function(res) {
       return new Promise(function(resolve, reject) {
-        const headers = {
+        stream.pushStream({
           ':path': res.url.pathname + res.url.search,
-        }
-
-        res.headers.forEach((function(value, header) {
-          headers[header] = value
-        }))
-
-        stream.pushStream(headers, function(err, pushStream) {
+        }, function(err, pushStream) {
           if (err) {
             reject(err)
           }
           else {
-            pushStream.respond({
-              ':status': res.status,
-            })
+             const headers = {
+               ':status': res.status,
+             }
+
+            res.headers.forEach((function(value, header) {
+              headers[header] = value
+            }))
+            
+            pushStream.respond(headers)
             writeResponseToWritableStream(pushStream, res)
             .then(resolve, reject)
           }


### PR DESCRIPTION
When pushing a stream of a `<script type="module">/* ... */</script>` to the browser, the runtime would error out with:

```
Failed to load module script: The server responded with a non-JavaScript MIME type of "". Strict MIME type checking is enforced for module scripts per HTML spec.
```
It came to my attention that the headers were missing (only `status` was present) because of this, for any content pushed from the server (`type="modules"` was the only one to complain). The changes here address that.